### PR TITLE
Cross-Site Scripting (XSS) : issue fix by sanitizing strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,18 +63,21 @@
     "d3-selection": "^1.4.0",
     "d3-shape": "^1.3.5",
     "d3-svg-annotation": "^2.4.0",
-    "d3-transition": "^1.2.0"
+    "d3-transition": "^1.2.0",
+    "dompurify": "^2.2.2"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",
     "@babel/preset-env": "^7.4.2",
     "@types/d3": "^5.7.1",
+    "@types/dompurify": "^2.0.4",
     "@types/node": "^11.12.0",
     "babelify": "^10.0.0",
     "browserify": "^16.2.3",
     "cssnano": "^4.1.10",
     "d3": "^5.9.2",
     "gitbook": "^3.2.3",
+    "gitbook-cli": "^2.3.2",
     "gitbook-plugin-custom-favicon": "0.0.4",
     "gitbook-plugin-ga": "^1.0.1",
     "gitbook-plugin-toggle-chapters": "0.0.3",
@@ -99,8 +102,7 @@
     "styled-jsx-plugin-postcss": "^2.0.0",
     "tsify": "^4.0.1",
     "typescript": "^3.3.4000",
-    "uglify-js": "^3.5.2",
-    "gitbook-cli": "^2.3.2"
+    "uglify-js": "^3.5.2"
   },
   "files": [
     "/dist",

--- a/src/scripts/chartAdvanced/pie.js
+++ b/src/scripts/chartAdvanced/pie.js
@@ -1,4 +1,6 @@
 import functor from '../util/functor';
+import sanitize from '../util/sanitize';
+
 
 /**
  * d2b.chartPieAdvanced(chart, datum) configures the input chart and formats a returned datum set
@@ -9,7 +11,7 @@ export default function (chart, datum) {
 
   // Chart Config
   chart
-    .label(d => d.label)
+    .label(d => sanitize(d.label))
     .value(d => d.value)
     .duration.conditionally(datum.duration)
     .donutRatio.conditionally(datum.donutRatio)

--- a/src/scripts/util/sanitize.js
+++ b/src/scripts/util/sanitize.js
@@ -1,0 +1,10 @@
+import Dompurify from "dompurify";
+
+
+/**
+ * Returns sanitized string prior to render.
+ * @param {string} string 
+ */
+export default function sanitize(v) {
+  return Dompurify.sanitize(v);
+}


### PR DESCRIPTION
### 📊 Metadata *

d2b is vulnerable to Cross-Site Scripting (XSS).

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-d2b

### ⚙️ Description *

Cross-Site Scripting (XSS) attacks are a type of injection, in which malicious scripts are injected into otherwise benign and trusted websites. XSS attacks occur when an attacker uses a web application to send malicious code, generally in the form of a browser side script, to a different end user. Flaws that allow these attacks to succeed are quite widespread and occur anywhere a web application uses input from a user within the output it generates without validating or encoding it.

### 💻 Technical Description *

Cross-Site Scripting (XSS) attacks are mitigated by sanitizing the user inputs before rendering, thereby preventing malicious execution.

### 🐛 Proof of Concept (PoC) *

1. Open https://www.npmjs.com/package/d2b
2. Open docs http://docs.d2bjs.org/ (You can see the d2b API references here.)
3. Select any chart(Ex:pie chart http://docs.d2bjs.org/chartsAdvanced/pie.html)
4. Edit in Codesandbox https://codesandbox.io/s/github/d2bjs/demos/tree/master/charts/pie/default-donut?from-embed
5. We can change the version("d2b": "1.0.12")in `package.json` https://codesandbox.io/s/d2b-pie-default-donut-demo-forked-seghw?file=/package.json:231-246 see the screenshots.
6. Insert the xss payload in any of the label field in data. EX: `{label: 'arc 1"><img src=x onerror=alert(1)>', value: 23},`
7. XSS payload will get executed.

### 🔥 Proof of Fix (PoF) *

Before:

![poc-before-xss](https://user-images.githubusercontent.com/64132745/100545418-b55ef000-3281-11eb-8f27-58e3c4ba8c13.png)

After:

![poc-after-xss](https://user-images.githubusercontent.com/64132745/100545468-f35c1400-3281-11eb-892f-d488c59bd76b.png)


### 👍 User Acceptance Testing (UAT)

![poc-test](https://user-images.githubusercontent.com/64132745/100545496-15ee2d00-3282-11eb-983c-14d832aa5e01.png)

After the fix, functionality is unaffected.
